### PR TITLE
Fix release-image-info.json

### DIFF
--- a/disconnected-oas.unified.bootstrap.sh
+++ b/disconnected-oas.unified.bootstrap.sh
@@ -886,7 +886,7 @@ for version in $(cat ${MIRROR_DIR}/ai-svc/cluster-versions.json | jq -r '.[] | @
 {"openshift_version":"$VERSION_SHORT","cpu_architecture":"${RHCOS_ARCHITECTURE}","url":"https://mirror.${ISOLATED_NETWORK_DOMAIN}/pub/downloads/rhcos/${VERSION_FULL}/rhcos-live.$RHCOS_ARCHITECTURE.iso","rootfs_url":"https://mirror.${ISOLATED_NETWORK_DOMAIN}/pub/downloads/rhcos/${VERSION_FULL}/rhcos-live-rootfs.$RHCOS_ARCHITECTURE.img","version":"$(cat ${MIRROR_DIR}/downloads/rhcos/${VERSION_FULL}/version)"}
 EOF
   cat > ${MIRROR_DIR}/downloads/rhcos/${VERSION_FULL}/release-image-info.json <<EOF
-{"openshift_version":"$VERSION_SHORT","cpu_architecture":"${RHCOS_ARCHITECTURE}","url":"${LOCAL_REGISTRY}.${ISOLATED_NETWORK_DOMAIN}/${LOCAL_REPOSITORY}:${OCP_RELEASE}-${ARCHITECTURE}","version":"$VERSION_FULL"}
+{"openshift_version":"$VERSION_SHORT","cpu_architecture":"${RHCOS_ARCHITECTURE}","url":"${LOCAL_REGISTRY}.${ISOLATED_NETWORK_DOMAIN}/${LOCAL_REPOSITORY}:${VERSION_FULL}-${ARCHITECTURE}","version":"$VERSION_FULL"}
 EOF
 oc_version() {
   cat <<EOF

--- a/disconnected-oas.unified.bootstrap.sh
+++ b/disconnected-oas.unified.bootstrap.sh
@@ -890,7 +890,7 @@ EOF
 EOF
 oc_version() {
   cat <<EOF
-"$VERSION_SHORT":{"display_name":"${VERSION_FULL}","release_version":"${VERSION_FULL}","release_image":"${LOCAL_REGISTRY}.${ISOLATED_NETWORK_DOMAIN}/${LOCAL_REPOSITORY}:${OCP_RELEASE}-${ARCHITECTURE}","rhcos_image":"https://mirror.${ISOLATED_NETWORK_DOMAIN}/pub/downloads/rhcos/${VERSION_FULL}/rhcos-live.$RHCOS_ARCHITECTURE.iso","rhcos_rootfs":"https://mirror.${ISOLATED_NETWORK_DOMAIN}/pub/downloads/rhcos/${VERSION_FULL}/rhcos-live-rootfs.$RHCOS_ARCHITECTURE.img","rhcos_version":"$(cat ${MIRROR_DIR}/downloads/rhcos/${VERSION_FULL}/version)","support_level":"production"},
+"$VERSION_SHORT":{"display_name":"${VERSION_FULL}","release_version":"${VERSION_FULL}","release_image":"${LOCAL_REGISTRY}.${ISOLATED_NETWORK_DOMAIN}/${LOCAL_REPOSITORY}:${VERSION_FULL}-${ARCHITECTURE}","rhcos_image":"https://mirror.${ISOLATED_NETWORK_DOMAIN}/pub/downloads/rhcos/${VERSION_FULL}/rhcos-live.$RHCOS_ARCHITECTURE.iso","rhcos_rootfs":"https://mirror.${ISOLATED_NETWORK_DOMAIN}/pub/downloads/rhcos/${VERSION_FULL}/rhcos-live-rootfs.$RHCOS_ARCHITECTURE.img","rhcos_version":"$(cat ${MIRROR_DIR}/downloads/rhcos/${VERSION_FULL}/version)","support_level":"production"},
 EOF
 }
   COMPILED_OPENSHIFT_VERSIONS+=$(oc_version)


### PR DESCRIPTION
OCP_RELEASE gets defined line 906, so after its invocation line 889 to create the file. 
As such, the `RELEASE_IMAGES` param in the Assisted Installer `onprem-environment` config is missing the version in the URL, as depicted below
```
RELEASE_IMAGES=[{"openshift_version":"4.10","cpu_architecture":"x86_64","url":"mirror-vm.isolated.local/ocp4/openshift4:-x86_64","version":"4.10.14"}]
```
This results in the ai-api container failing to start with the following error
```
FATA[0000]/go/src/github.com/openshift/origin/cmd/main.go:196 main.main.func1() failed to create pull secret validator        error="invalid reference format"
```